### PR TITLE
2.9 bugfixes and additions

### DIFF
--- a/Dropzone/ControlManifest.Input.xml
+++ b/Dropzone/ControlManifest.Input.xml
@@ -1,11 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="GorgonUK" constructor="Dropzone" version="0.0.55" display-name-key="Modern Dropzone" description-key="Modern Dropzone component for Dynamics365 that integrates with Notes and SharePoint OOTB" control-type="virtual">
+  <control namespace="GorgonUK" constructor="Dropzone" version="0.0.61" display-name-key="Modern Dropzone" description-key="Modern Dropzone component for Dynamics365 that integrates with Notes and SharePoint OOTB" control-type="virtual">
     <data-set name="sampleDataSet" display-name-key="Select any table">
     </data-set>
     <property name="enableSharePointDocuments" display-name-key="Enable SharePoint Documents?" description-key="Simply provide Yes/No" of-type="TwoOptions" usage="input" required="true" default-value="true" />
-    <property name="allowNoteDrops" display-name-key="Allow Note Drops?" description-key="Simply provide Yes/No" of-type="TwoOptions" usage="input" required="true" default-value="true" />
-    <property name="allowSharePointDrops" display-name-key="Allow SharePoint Drops?" description-key="Enable or disable SharePoint drops (True/False)" of-type="TwoOptions" usage="input" required="true" default-value="true" />
+    <property name="allowNoteDrops" display-name-key="Allow Note drops?" description-key="Allow users to upload documents to Notes?" of-type="TwoOptions" usage="input" required="true" default-value="true" />
+    <property name="allowSharePointDrops" display-name-key="Allow SharePoint drops?" description-key="Allow users to upload documents to SharePoint?" of-type="TwoOptions" usage="input" required="true" default-value="true" />
+    <property name="displayNotesViewsControl" display-name-key="Display Notes views dropdown?" description-key="Enable users to change Notes views" of-type="TwoOptions" usage="input" required="true" default-value="true" />
+    <property name="enableNotesViewsControl" display-name-key="Enable Notes views dropdown?" description-key="Enable users to change Notes views" of-type="TwoOptions" usage="input" required="true" default-value="true" />
+    <property name="displaySharePointDocumentLocationsControl" display-name-key="Display SharePoint document locations dropdown?" description-key="Enable users to change SP Document Location" of-type="TwoOptions" usage="input" required="true" default-value="true" />
+    <property name="enableSharePointDocumentLocationsControl" display-name-key="Enable SharePoint document locations dropdown?" description-key="Enable users to change SP Document Location" of-type="TwoOptions" usage="input" required="true" default-value="true" />
+    <property name="defaultNotesView" display-name-key="Default Notes View" description-key="Default Notes view" of-type="SingleLine.Text" usage="input" required="false" />
     <resources>
       <code path="index.ts" order="1" />
       <platform-library name="React" version="16.8.6" />

--- a/Dropzone/Interfaces.ts
+++ b/Dropzone/Interfaces.ts
@@ -71,3 +71,22 @@ export type GenericActionResponse = {
     success: boolean;
     message: string;
   };
+
+  export interface NoteView {
+    savedqueryid: string;   // GUID
+    name: string;
+    fetchxml: string;
+  }
+  
+  export type NoteViewSuccess = {
+    success: true;
+    data: NoteView[];
+  };
+  
+  export type NoteViewError = {
+    success: false;
+    message: string;
+    data: [];
+  };
+  
+  export type NoteViewResult = NoteViewSuccess | NoteViewError;

--- a/Dropzone/index.ts
+++ b/Dropzone/index.ts
@@ -15,7 +15,7 @@ export class Dropzone
     state: ComponentFramework.Dictionary,
     container: HTMLDivElement
   ): void {
-    console.log("Dropzone PCF 2.8 Initialised");
+    console.log("Dropzone PCF 2.9 Initialised");
     this.theContainer = container;
     this.notifyOutputChanged = notifyOutputChanged;
     this.webAPI = context.webAPI;
@@ -62,7 +62,8 @@ export class Dropzone
   public updateView(
     context: ComponentFramework.Context<IInputs>
   ): React.ReactElement {
-    return React.createElement(Landing, { context: context });
+    let isDisabled = context.mode.isControlDisabled;
+    return React.createElement(Landing, { context: context, isDisabled });
   }
   public getOutputs(): IOutputs {
     return {};

--- a/Solution/ModernDropzone/src/Other/Solution.xml
+++ b/Solution/ModernDropzone/src/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="ModernDropzone" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.4</Version>
+    <Version>1.0.7</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>


### PR DESCRIPTION
## 🐞 Bug Fixes

- Resolved issue with unrelated Notes/SharePoint Documents appearing. #34 
- Fixed SharePoint Document Location handling.

## ✨ New Features

- **Disable Control via Form Script**  #38 
  Use the following to disable the component programmatically:  
  `Xrm.Page.getControl("Control_ID").setDisabled(true)`  
  or  
  `formContext.getControl("Control_ID").setDisabled(true)`

- **View Selector Support**  #28 
  Users can now switch between Note(annotation) views on the form.
![image](https://github.com/user-attachments/assets/379d2545-37d8-4825-8f7b-cf371cc665f8)
![image](https://github.com/user-attachments/assets/c5af7433-5142-4fca-9731-c3b98e1ca4ac)
To set a default view, open the form where the control is added, click the three dots next to Modern Dropzone in the settings pane, and enter the name of the view under Default Notes View.
![image](https://github.com/user-attachments/assets/ab37176d-1312-4b72-a716-4f0e4624143c)


- **Configurable Parameters**  
  Introduced multiple new control parameters for customization and flexibility.
